### PR TITLE
Update registrarmodule.php

### DIFF
--- a/modules/registrars/registrarmodule/registrarmodule.php
+++ b/modules/registrars/registrarmodule/registrarmodule.php
@@ -578,7 +578,6 @@ function registrarmodule_GetNameservers($params)
         $api->call('GetNameservers', $postfields);
 
         return array(
-
             'ns1' => $api->getFromResponse('nameserver1'),
             'ns2' => $api->getFromResponse('nameserver2'),
             'ns3' => $api->getFromResponse('nameserver3'),

--- a/modules/registrars/registrarmodule/registrarmodule.php
+++ b/modules/registrars/registrarmodule/registrarmodule.php
@@ -578,7 +578,7 @@ function registrarmodule_GetNameservers($params)
         $api->call('GetNameservers', $postfields);
 
         return array(
-            'success' => true,
+
             'ns1' => $api->getFromResponse('nameserver1'),
             'ns2' => $api->getFromResponse('nameserver2'),
             'ns3' => $api->getFromResponse('nameserver3'),


### PR DESCRIPTION
Fixed a bug in registrarmodule_GetNameservers (the first element of the result was a "success" element, but it seems that it was used only by very old versions of WHMCS: currently, and with a number of WHMCS versions, it gives an error in client area.
See also here:  https://whmcs.community/topic/315797-domain-nameservers-not-returned-correctly/